### PR TITLE
Existing COGs and Date Range Options

### DIFF
--- a/src/stactools/noaa_nclimgrid/cog.py
+++ b/src/stactools/noaa_nclimgrid/cog.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, Optional
+from typing import Dict, List, Optional
 
 import fsspec
 import numpy as np
@@ -7,8 +7,8 @@ import rasterio
 import rasterio.shutil
 import xarray
 from rasterio.io import MemoryFile
-from stactools.core.utils import href_exists
 from stactools.core.io import ReadHrefModifier
+from stactools.core.utils import href_exists
 
 from stactools.noaa_nclimgrid.constants import Variable
 
@@ -61,39 +61,89 @@ def cog_time_slice(
 
 def create_cogs(
     nc_hrefs: Dict[Variable, str],
-    cog_dir: str,
+    cog_paths: Dict[Variable, str],
     day: Optional[int] = None,
-    month: Optional[Dict[str, Any]] = None,
+    month: Optional[int] = None,
     cog_check_href: Optional[str] = None,
     read_href_modifier: Optional[ReadHrefModifier] = None,
-) -> Dict[Variable, str]:
+) -> List[str]:
     """Creates a prcp, tavg, tmax, and tmin COGS for a single temporal unit.
 
     A temporal unit is a day for daily data or a month for monthly data.
 
     Args:
-        nc_hrefs (Dict[Variable, str]): A dictionary mapping variables (keys) to
-            netCDF HREFs (values).
-        cog_dir (str): Destination directory for created COGs.
+        nc_hrefs (Dict[Variable, str]): A dictionary mapping variables to netCDF
+            HREFs.
+        cog_paths (Dict[Variable, str]): A dictionary mapping variables to
+            target COG HREFs.
         day (Optional[int], optional): Day of month. Used to index into the
             data timestacks. Only specify for daily data.
-        month (Optional[Dict[str, Any]], optional): Months since January 1895
-            where January 1895 is month=1. Used to index into the data
-            timestacks. Only specify for monthly data.
+        month (Optional[int], optional): Months since January 1895 where January
+            1895 is month=1. Used to index into the data timestacks. Only
+            specify for monthly data.
         cog_check_href (Optional[str]): HREF to a location to check for existing
-            COG files. This can be as simple as the same local directory as
-            `cog_href` or a remote directory, e.g., an Azure directory. New COGs
-            are not created if existing COGs are found.
+            COG files. This can be as simple as the same local directory as in
+            `cog_paths` or a remote directory, e.g., an Azure directory. New
+            COGs are not created if existing COGs are found.
         read_href_modifier (Optional[ReadHrefModifier]): An optional function
             to modify an href (e.g., to add a token to a url).
 
     Returns:
-        Dict[Variable, str]: A dictionary mapping variables (keys) to COG HREFs
-            (values).
+        List[str]: List of created COG HREFs.
+    """
+    if day:
+        time_index = day - 1
+    elif month:
+        time_index = month - 1
+
+    for var in Variable:
+        cog_exists = False
+        if cog_check_href is not None:
+            cog_exists = _check_cog_existence(
+                cog_paths[var], cog_check_href, read_href_modifier=read_href_modifier
+            )
+        if cog_exists:
+            cog_paths.pop(var)
+        else:
+            cog_time_slice(nc_hrefs[var], var, cog_paths[var], time_index)
+
+    return list(cog_paths.values())
+
+
+def _check_cog_existence(
+    local_cog_path: str,
+    cog_check_href: str,
+    read_href_modifier: Optional[ReadHrefModifier] = None,
+) -> bool:
+    check_href = os.path.join(cog_check_href, os.path.basename(local_cog_path))
+    if read_href_modifier is not None:
+        read_check_href = read_href_modifier(check_href)
+    else:
+        read_check_href = check_href
+    return href_exists(read_check_href)
+
+
+def create_cog_paths(
+    nc_hrefs: Dict[Variable, str],
+    cog_dir: str,
+    day: Optional[int] = None,
+    month: Optional[str] = None,
+) -> Dict[Variable, str]:
+    """Generate target local path and name for COGs.
+
+    Args:
+        nc_hrefs (Dict[Variable, str]): Dictionary of NetCDF file HREFs
+        cog_dir (str): Target COG storage directory
+        day (Optional[int], optional): Day of month. Only specify for daily
+            data.
+        month (Optional[str], optional): YYYYMM string. Only specify for
+            monthly data.
+
+    Returns:
+        Dict[Variable, str]: A dictionary mapping variables to target COG HREFs.
     """
     cog_paths = {}
     if day:
-        time_index = day - 1
         basenames = {
             var: os.path.splitext(os.path.basename(nc_hrefs[var]))[0]
             for var in Variable
@@ -103,20 +153,7 @@ def create_cogs(
             for var in Variable
         }
     elif month:
-        time_index = month["idx"] - 1
-        filenames = {var: f"nclimgrid-{var}-{month['date']}.tif" for var in Variable}
+        filenames = {var: f"nclimgrid-{var}-{month}.tif" for var in Variable}
         cog_paths = {var: os.path.join(cog_dir, filenames[var]) for var in Variable}
-
-    for var in Variable:
-        cog_exists = False
-        if cog_check_href is not None:
-            check_href = os.path.join(cog_check_href, os.path.basename(cog_paths[var]))
-            if read_href_modifier is not None:
-                read_check_href = read_href_modifier(check_href)
-            else:
-                read_check_href = check_href
-            cog_exists = href_exists(read_check_href)
-        if not cog_exists:
-            cog_time_slice(nc_hrefs[var], var, cog_paths[var], time_index)
 
     return cog_paths

--- a/src/stactools/noaa_nclimgrid/commands.py
+++ b/src/stactools/noaa_nclimgrid/commands.py
@@ -1,10 +1,11 @@
 import logging
 import os
 from tempfile import TemporaryDirectory
+from typing import List
 
 import click
 from click import Command, Group
-from pystac import CatalogType
+from pystac import CatalogType, Item
 from stactools.core.copy import move_asset_file_to_item
 
 from stactools.noaa_nclimgrid import stac
@@ -57,11 +58,11 @@ def create_noaa_nclimgrid_command(cli: Group) -> Command:
         with open(infile) as f:
             hrefs = [os.path.abspath(line.strip()) for line in f.readlines()]
 
-        items = []
+        items: List[Item] = []
         frequency = data_frequency(hrefs[0])
         with TemporaryDirectory() as cog_dir:
             for href in hrefs:
-                temp_items = stac.create_items(href, cog_dir, nc_assets=nc_assets)
+                temp_items, _ = stac.create_items(href, cog_dir, nc_assets=nc_assets)
                 items.extend(temp_items)
 
             collection = stac.create_collection(frequency, nc_assets)
@@ -116,7 +117,7 @@ def create_noaa_nclimgrid_command(cli: Group) -> Command:
             nc_assets (bool): Flag to include source netCDF file assets in
                 created Items. Default is False.
         """
-        items = stac.create_items(infile, cogdir, nc_assets=nc_assets)
+        items, _ = stac.create_items(infile, cogdir, nc_assets=nc_assets)
         for item in items:
             item_path = os.path.join(itemdir, f"{item.id}.json")
             item.set_self_href(item_path)

--- a/src/stactools/noaa_nclimgrid/commands.py
+++ b/src/stactools/noaa_nclimgrid/commands.py
@@ -109,10 +109,17 @@ def create_noaa_nclimgrid_command(cli: Group) -> Command:
     )
     @click.option(
         "-d",
-        "--daily-range",
+        "--day-range",
         nargs=2,
         type=int,
         help="Desired start and end day of month for daily data",
+    )
+    @click.option(
+        "-m",
+        "--month-range",
+        nargs=2,
+        type=str,
+        help="Desired start and end month in YYYYMM format for monthly data",
     )
     def create_items_command(
         infile: str,
@@ -120,7 +127,8 @@ def create_noaa_nclimgrid_command(cli: Group) -> Command:
         itemdir: str,
         nc_assets: bool,
         cog_check_href: Optional[str] = None,
-        daily_range: Optional[Tuple[int, int]] = None,
+        day_range: Optional[Tuple[int, int]] = None,
+        month_range: Optional[Tuple[str, str]] = None,
     ) -> None:
         """Creates COGs and STAC Items for each day or month in the daily or
         monthly netCDF INFILE.
@@ -139,15 +147,18 @@ def create_noaa_nclimgrid_command(cli: Group) -> Command:
                 are found. The `cog_check_href` can simply be the same local
                 directory as `cogdir` or a remote directory, e.g., an Azure
                 blob storage container.
-            daily_range (Optional[Tuple[int, int]]): Optional start and end day
+            day_range (Optional[Tuple[int, int]]): Optional start and end day
                 of month for daily data
+            month_range (Optional[Tuple[int, int]]): Optional start and end
+                month in YYYYMM format for monthly data.
         """
         items, _ = stac.create_items(
             infile,
             cogdir,
             nc_assets=nc_assets,
             cog_check_href=cog_check_href,
-            daily_range=daily_range,
+            day_range=day_range,
+            month_range=month_range,
         )
         for item in items:
             item_path = os.path.join(itemdir, f"{item.id}.json")

--- a/src/stactools/noaa_nclimgrid/stac.py
+++ b/src/stactools/noaa_nclimgrid/stac.py
@@ -95,11 +95,11 @@ def create_items(
     cog_dir: str,
     nc_assets: bool = False,
     cog_check_href: Optional[str] = None,
-    daily_range: Optional[Tuple[int, int]] = None,
-    monthly_range: Optional[Tuple[str, str]] = None,
+    day_range: Optional[Tuple[int, int]] = None,
+    month_range: Optional[Tuple[str, str]] = None,
     read_href_modifier: Optional[ReadHrefModifier] = None,
 ) -> Tuple[List[Item], List[str]]:
-    """Creates STAC Items for all temporal units in set of netCDF files.
+    """Creates STAC Items for temporal units in set of netCDF files.
 
     A temporal unit is a day for daily data or a month for monthly data. A set
     of netCDF files refers to 'prcp', 'tavg', 'tmin', and 'tmax'
@@ -118,8 +118,12 @@ def create_items(
             `cog_check_href` can simply be the same local directory as
             `cog_href` or a remote directory, e.g., an Azure blob storage
             container.
-        daily_range
-        monthly_range
+        day_range (Optional[Tuple[int, int]]): An optional tuple of desired
+            start and end day of month for daily data. For example:
+            (<start_day_of_month>, <end_day_of_month>)
+        month_range (Optional[Tuple[str, str]]): An optional tuple of desired
+            start and end YYYYMM date strings. For example: (<start_YYYYMM>,
+            <end_YYYYMM>).
         read_href_modifier (Optional[ReadHrefModifier]): An optional function
             to modify an href (e.g., to add a token to a url).
 
@@ -141,7 +145,7 @@ def create_items(
     if frequency == Frequency.DAILY:
         days = day_indices(
             nc_hrefs[Variable.PRCP],
-            daily_range=daily_range,
+            day_range=day_range,
             read_href_modifier=read_href_modifier,
         )
         for day in days:
@@ -160,9 +164,10 @@ def create_items(
                 items.append(create_item(cog_hrefs))
 
     else:
-        # pass monthly_range to this function
         months = month_indices(
-            nc_hrefs[Variable.PRCP], read_href_modifier=read_href_modifier
+            nc_hrefs[Variable.PRCP],
+            month_range=month_range,
+            read_href_modifier=read_href_modifier,
         )
         for month in months:
             cog_hrefs, created_cog_hrefs = create_cogs(

--- a/src/stactools/noaa_nclimgrid/stac.py
+++ b/src/stactools/noaa_nclimgrid/stac.py
@@ -139,12 +139,12 @@ def create_items(
     items: List[Item] = []
     created_cogs: List[str] = []
     if frequency == Frequency.DAILY:
-        # pass daily_range to this function
         days = day_indices(
-            nc_hrefs[Variable.PRCP], read_href_modifier=read_href_modifier
+            nc_hrefs[Variable.PRCP],
+            daily_range=daily_range,
+            read_href_modifier=read_href_modifier,
         )
         for day in days:
-            # how about a yield for a generator?
             cog_hrefs, created_cog_hrefs = create_cogs(
                 nc_hrefs,
                 cog_dir,
@@ -165,7 +165,6 @@ def create_items(
             nc_hrefs[Variable.PRCP], read_href_modifier=read_href_modifier
         )
         for month in months:
-            # how about a yield for a generator?
             cog_hrefs, created_cog_hrefs = create_cogs(
                 nc_hrefs,
                 cog_dir,

--- a/src/stactools/noaa_nclimgrid/stac.py
+++ b/src/stactools/noaa_nclimgrid/stac.py
@@ -1,7 +1,7 @@
 import os
 from calendar import monthrange
 from datetime import datetime, timezone
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Tuple
 
 import stactools.core.create
 from pystac import Asset, Collection, Item
@@ -94,7 +94,9 @@ def create_items(
     nc_href: str,
     cog_dir: str,
     nc_assets: bool = False,
-    short_circuit: Optional[Callable[[str], bool]] = None,
+    force_cog_creation: bool = False,
+    daily_range: Optional[Tuple(int, int)] = None,
+    monthly_range: Optional[Tuple(str, str)] = None,
     read_href_modifier: Optional[ReadHrefModifier] = None,
 ) -> List[Item]:
     """Creates STAC Items for all temporal units in set of netCDF files.
@@ -111,8 +113,9 @@ def create_items(
         cog_dir (str): Destination directory for COGs which will be created.
         nc_assets (bool): Flag to include Item assets for the source netCDF
             files. Default is False.
-        short_circuit (Optional[Callable[[str], bool]]): A placeholder
-            for an optional function that checks for existing Items and/or COGs.
+        force_cog_creation
+        daily_range
+        monthly_range
         read_href_modifier (Optional[ReadHrefModifier]): An optional function
             to modify an href (e.g., to add a token to a url).
 

--- a/src/stactools/noaa_nclimgrid/utils.py
+++ b/src/stactools/noaa_nclimgrid/utils.py
@@ -76,7 +76,7 @@ def nc_href_dict(nc_href: str) -> Dict[Variable, str]:
 
 def day_indices(
     nc_prcp_href: str,
-    daily_range: Optional[Tuple[int, int]] = None,
+    day_range: Optional[Tuple[int, int]] = None,
     read_href_modifier: Optional[ReadHrefModifier] = None,
 ) -> List[int]:
     """Creates a list of days, in descending order, with valid precipitation
@@ -89,9 +89,9 @@ def day_indices(
 
     Args:
         nc_prcp_href (str): HREF to daily netCDF precipitation file.
-        daily_range (Optional[Tuple[int, int]]): An optional tuple of desired
+        day_range (Optional[Tuple[int, int]]): An optional tuple of desired
             start and end day of month. For example: (<start_day_of_month>,
-            <end_day_of_month>)
+            <end_day_of_month>).
         read_href_modifier (Optional[ReadHrefModifier]): An optional function
             to modify an href (e.g., to add a token to a url).
 
@@ -107,14 +107,20 @@ def day_indices(
             min_prcp = dataset.prcp.min(dim=("lat", "lon"), skipna=True).values
             days = sum(min_prcp >= 0)
 
-    if daily_range is not None:
-        if daily_range[0] <= daily_range[1]:
-            day_start = daily_range[0] if daily_range[0] > 1 else 1
-            day_end = daily_range[1] if daily_range[1] < days else days
-        else:
+    if day_range:
+        if day_range[0] < 1:
+            raise ValueError("Minimum day in 'day_range' must be >= 1")
+        elif day_range[1] > days:
             raise ValueError(
-                "The second element of 'daily_range' must be <= to the first element."
+                "Maximum day in 'day_range' is posterior to available data"
             )
+        elif day_range[0] > day_range[1]:
+            raise ValueError(
+                "The second element of 'day_range' must be >= to the first element."
+            )
+        else:
+            day_start = day_range[0] if day_range[0] > 1 else 1
+            day_end = day_range[1] if day_range[1] < days else days
     else:
         day_start = 1
         day_end = days
@@ -124,6 +130,7 @@ def day_indices(
 
 def month_indices(
     nc_href: str,
+    month_range: Optional[Tuple[str, str]] = None,
     read_href_modifier: Optional[ReadHrefModifier] = None,
 ) -> List[Dict[str, Any]]:
     """Creates a list of dictionaries, where each dictionary contains an index
@@ -132,12 +139,15 @@ def month_indices(
 
     Args:
         nc_href (str): HREF to a monthly netCDF file.
+        month_range (Optional[Tuple[str, str]]): An optional tuple of desired
+            start and end YYYYMM date strings. For example: (<start_YYYYMM>,
+            <end_YYYYMM>).
         read_href_modifier (Optional[ReadHrefModifier]): An optional function
             to modify an href (e.g., to add a token to a url).
 
     Returns:
-        List[Dict[str, Any]]: List of dictionaries with index and timeslice
-            information.
+        List[Dict[str, Any]]: List of dictionaries with indices into the NetCDF
+            timestack and corresponding YYYYMM date strings for each time slice.
     """
     read_nc_href = modify_href(nc_href, read_href_modifier=read_href_modifier)
     with fsspec.open(read_nc_href) as fobj:
@@ -145,9 +155,30 @@ def month_indices(
             years = ds.time.dt.year.data.tolist()
             months = ds.time.dt.month.data.tolist()
 
-    idx_month = []
+    idx_month: List[Dict[str, Any]] = []
     for idx, (year, month) in enumerate(zip(years, months), start=1):
         idx_month.append({"idx": idx, "date": f"{year}{month:02d}"})
+
+    if month_range:
+        idx_month.sort(key=operator.itemgetter("idx"))
+        if int(month_range[0]) < int(idx_month[0]["date"]):
+            raise ValueError(
+                f"'month_range' start YYYYMM ({month_range[0]}) is prior to available data"
+            )
+        elif int(month_range[1]) > int(idx_month[-1]["date"]):
+            raise ValueError(
+                f"'month_range' start YYYYMM ({month_range[1]}) is posterior to available data"
+            )
+        elif int(month_range[0]) > int(month_range[1]):
+            raise ValueError(
+                "The second element of 'month_range' must be >= to the first element."
+            )
+        else:
+            idx_month = [
+                m
+                for m in idx_month
+                if int(month_range[0]) <= int(m["date"]) <= int(month_range[1])
+            ]
 
     idx_month.sort(key=operator.itemgetter("idx"), reverse=True)
 

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -1,5 +1,4 @@
 from tempfile import TemporaryDirectory
-from typing import Optional
 
 from stactools.noaa_nclimgrid import cog
 from stactools.noaa_nclimgrid.constants import Variable
@@ -22,16 +21,16 @@ def test_check_cog_existence() -> None:
         ),
     }
     with TemporaryDirectory() as cog_dir:
-        month_idx: Optional[int] = 1
-        month_date: Optional[str] = "189502"
-        target_cog_paths = cog.create_cog_paths(nc_hrefs, cog_dir, month=month_date)
+        month = {"idx": 1, "date": "189502"}
         for var in [Variable.PRCP, Variable.TAVG]:
-            with open(target_cog_paths[var], "w") as _:
+            target_cog_path = cog.get_cog_href(nc_hrefs[var], var, cog_dir, month=month)
+            with open(target_cog_path, "w") as _:
                 pass
-        created_cog_paths = cog.create_cogs(
-            nc_hrefs, target_cog_paths, month=month_idx, cog_check_href=cog_dir
+        cog_hrefs, created_cog_hrefs = cog.create_cogs(
+            nc_hrefs, cog_dir, month=month, cog_check_href=cog_dir
         )
-        assert len(created_cog_paths) == 2
+        assert len(cog_hrefs) == 4
+        assert len(created_cog_hrefs) == 2
 
 
 def test_create_cogs() -> None:
@@ -50,8 +49,9 @@ def test_create_cogs() -> None:
         ),
     }
     with TemporaryDirectory() as cog_dir:
-        month_idx: Optional[int] = 1
-        month_date: Optional[str] = "189502"
-        target_cog_paths = cog.create_cog_paths(nc_hrefs, cog_dir, month=month_date)
-        created_cog_paths = cog.create_cogs(nc_hrefs, target_cog_paths, month=month_idx)
-        assert len(created_cog_paths) == 4
+        month = {"idx": 1, "date": "189502"}
+        cog_hrefs, created_cog_hrefs = cog.create_cogs(
+            nc_hrefs, cog_dir, month=month, cog_check_href=cog_dir
+        )
+        assert len(cog_hrefs) == 4
+        assert len(created_cog_hrefs) == 4

--- a/tests/test_cog.py
+++ b/tests/test_cog.py
@@ -1,0 +1,57 @@
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+from stactools.noaa_nclimgrid import cog
+from stactools.noaa_nclimgrid.constants import Variable
+from tests import test_data
+
+
+def test_check_cog_existence() -> None:
+    nc_hrefs = {
+        Variable.PRCP: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_prcp.nc"
+        ),
+        Variable.TAVG: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tavg.nc"
+        ),
+        Variable.TMAX: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tmax.nc"
+        ),
+        Variable.TMIN: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tmin.nc"
+        ),
+    }
+    with TemporaryDirectory() as cog_dir:
+        month_idx: Optional[int] = 1
+        month_date: Optional[str] = "189502"
+        target_cog_paths = cog.create_cog_paths(nc_hrefs, cog_dir, month=month_date)
+        for var in [Variable.PRCP, Variable.TAVG]:
+            with open(target_cog_paths[var], "w") as _:
+                pass
+        created_cog_paths = cog.create_cogs(
+            nc_hrefs, target_cog_paths, month=month_idx, cog_check_href=cog_dir
+        )
+        assert len(created_cog_paths) == 2
+
+
+def test_create_cogs() -> None:
+    nc_hrefs = {
+        Variable.PRCP: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_prcp.nc"
+        ),
+        Variable.TAVG: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tavg.nc"
+        ),
+        Variable.TMAX: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tmax.nc"
+        ),
+        Variable.TMIN: test_data.get_path(
+            "data-files/netcdf/monthly/nclimgrid_tmin.nc"
+        ),
+    }
+    with TemporaryDirectory() as cog_dir:
+        month_idx: Optional[int] = 1
+        month_date: Optional[str] = "189502"
+        target_cog_paths = cog.create_cog_paths(nc_hrefs, cog_dir, month=month_date)
+        created_cog_paths = cog.create_cogs(nc_hrefs, target_cog_paths, month=month_idx)
+        assert len(created_cog_paths) == 4

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -1,7 +1,6 @@
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Optional
 
-from stactools.noaa_nclimgrid import cog, stac
+from stactools.noaa_nclimgrid import stac
 from stactools.noaa_nclimgrid.constants import Frequency, Variable
 from tests import test_data
 
@@ -9,7 +8,7 @@ from tests import test_data
 def test_create_monthly_items_local() -> None:
     nc_href = test_data.get_path("data-files/netcdf/monthly/nclimgrid_prcp.nc")
     with TemporaryDirectory() as cog_dir:
-        items = stac.create_items(nc_href, cog_dir)
+        items, _ = stac.create_items(nc_href, cog_dir)
         assert len(items) == 2
         for item in items:
             item.validate()
@@ -27,7 +26,7 @@ def test_create_monthly_items_local() -> None:
 def test_create_monthly_items_with_netcdf_assets() -> None:
     nc_href = test_data.get_path("data-files/netcdf/monthly/nclimgrid_prcp.nc")
     with TemporaryDirectory() as cog_dir:
-        items = stac.create_items(nc_href, cog_dir, nc_assets=True)
+        items, _ = stac.create_items(nc_href, cog_dir, nc_assets=True)
         assert len(items) == 2
         for item in items:
             assert len(item.assets) == 8
@@ -39,7 +38,7 @@ def test_create_daily_items_local() -> None:
         "data-files/netcdf/daily/beta/by-month/2022/01/prcp-202201-grd-prelim.nc"
     )
     with TemporaryDirectory() as cog_dir:
-        items = stac.create_items(nc_href, cog_dir)
+        items, _ = stac.create_items(nc_href, cog_dir)
         assert len(items) == 1
         for item in items:
             item.validate()
@@ -59,7 +58,7 @@ def test_create_daily_items_with_netcdf_assets() -> None:
         "data-files/netcdf/daily/beta/by-month/2022/01/prcp-202201-grd-prelim.nc"
     )
     with TemporaryDirectory() as cog_dir:
-        items = stac.create_items(nc_href, cog_dir, nc_assets=True)
+        items, _ = stac.create_items(nc_href, cog_dir, nc_assets=True)
         assert len(items) == 1
         for item in items:
             assert len(item.assets) == 8
@@ -85,27 +84,6 @@ def test_create_single_item() -> None:
     assert item.id == "nclimgrid-189501"
     assert len(item.assets) == 4
     item.validate()
-
-
-def test_create_cogs() -> None:
-    nc_hrefs = {
-        Variable.PRCP: test_data.get_path(
-            "data-files/netcdf/monthly/nclimgrid_prcp.nc"
-        ),
-        Variable.TAVG: test_data.get_path(
-            "data-files/netcdf/monthly/nclimgrid_tavg.nc"
-        ),
-        Variable.TMAX: test_data.get_path(
-            "data-files/netcdf/monthly/nclimgrid_tmax.nc"
-        ),
-        Variable.TMIN: test_data.get_path(
-            "data-files/netcdf/monthly/nclimgrid_tmin.nc"
-        ),
-    }
-    with TemporaryDirectory() as cog_dir:
-        month: Optional[Dict[str, Any]] = {"idx": 1, "date": "189502"}
-        cog_paths = cog.create_cogs(nc_hrefs, cog_dir, month=month)
-        assert len(cog_paths) == 4
 
 
 def test_read_href_modifier() -> None:
@@ -166,7 +144,3 @@ def test_str_asset_keys() -> None:
     for key in item.assets.keys():
         assert type(key) == str
     item.validate()
-
-
-def test_check_cog_existence() -> None:
-    pass

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -146,12 +146,21 @@ def test_str_asset_keys() -> None:
     item.validate()
 
 
-def test_daily_range() -> None:
+def test_day_range() -> None:
     nc_href = test_data.get_path(
         "data-files/netcdf/daily/beta/by-month/2022/01/prcp-202201-grd-prelim.nc"
     )
-    daily_range = (1, 1)
+    day_range = (1, 1)
     with TemporaryDirectory() as cog_dir:
-        items, cogs = stac.create_items(nc_href, cog_dir, daily_range=daily_range)
+        items, cogs = stac.create_items(nc_href, cog_dir, day_range=day_range)
+        assert len(items) == 1
+        assert len(cogs) == 4
+
+
+def test_month_range() -> None:
+    nc_href = test_data.get_path("data-files/netcdf/monthly/nclimgrid_prcp.nc")
+    month_range = ("189501", "189501")
+    with TemporaryDirectory() as cog_dir:
+        items, cogs = stac.create_items(nc_href, cog_dir, month_range=month_range)
         assert len(items) == 1
         assert len(cogs) == 4

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -166,3 +166,7 @@ def test_str_asset_keys() -> None:
     for key in item.assets.keys():
         assert type(key) == str
     item.validate()
+
+
+def test_check_cog_existence() -> None:
+    pass

--- a/tests/test_stac.py
+++ b/tests/test_stac.py
@@ -144,3 +144,14 @@ def test_str_asset_keys() -> None:
     for key in item.assets.keys():
         assert type(key) == str
     item.validate()
+
+
+def test_daily_range() -> None:
+    nc_href = test_data.get_path(
+        "data-files/netcdf/daily/beta/by-month/2022/01/prcp-202201-grd-prelim.nc"
+    )
+    daily_range = (1, 1)
+    with TemporaryDirectory() as cog_dir:
+        items, cogs = stac.create_items(nc_href, cog_dir, daily_range=daily_range)
+        assert len(items) == 1
+        assert len(cogs) == 4


### PR DESCRIPTION
**Related Issue(s):**
None

**Description:**
- Added option to check for existing COGs in a separate local or remote directory. If a COG exists, a new one is not created
- `create_items` now returns a list of Items and a list of created COGs
- Added options to restrict Item creation to a date range (daily or monthly)

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [ ] Examples have been updated to reflect changes, if applicable
- [ ] Changes are added to the [CHANGELOG](../CHANGELOG.md).
